### PR TITLE
 공간 조회 api 수정

### DIFF
--- a/app/api/spaces/(adaptor)/route.ts
+++ b/app/api/spaces/(adaptor)/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const spaceId = Number(searchParams.get('spaceId'));
-    
+
     // Supabase 클라이언트 생성
     const supabase = await createClient();
     const spaceRepository = new SbSpaceRepository(supabase);

--- a/backend/common/domains/entities/Room.ts
+++ b/backend/common/domains/entities/Room.ts
@@ -3,7 +3,7 @@ import { Supply } from './Supply';
 export class Room {
   constructor(
     public id: number,
-    // public supplyId: number,
+    public supplyId: number,
     public supplies: Supply[],
     public name: string,
     public detail: string | null,

--- a/backend/common/domains/entities/Room.ts
+++ b/backend/common/domains/entities/Room.ts
@@ -1,7 +1,10 @@
+import { Supply } from './Supply';
+
 export class Room {
   constructor(
     public id: number,
-    public supplyId: number,
+    // public supplyId: number,
+    public supplies: Supply[],
     public name: string,
     public detail: string | null,
     public roomItemId: number,

--- a/backend/common/infrastructures/repositories/SbRsvRepository.ts
+++ b/backend/common/infrastructures/repositories/SbRsvRepository.ts
@@ -8,79 +8,13 @@ import {
   SaveRequest,
   UpdateRequest,
 } from '../../domains/repositories/rsvRequest';
+import { mapKeysToCamelCase } from '../utils/CaseConvertUtils';
 
 export class SbRsvRepository implements RsvRepository {
   private supabase: SupabaseClient;
 
   constructor(supabase: SupabaseClient) {
     this.supabase = supabase;
-  }
-
-  private static mapToRsv(rsv: {
-    space_id: number;
-    room_id: number;
-    user_id: string;
-    id: string;
-    start_time: Date;
-    end_time: Date;
-    created_at?: Date;
-    edited_at?: Date;
-    deleted_at?: Date | null;
-    room?: {
-      id?: number;
-      supply_id?: number;
-      name?: string;
-      detail?: string;
-      roomItem_id?: number;
-      space_id?: number;
-      position_x?: number;
-      position_y?: number;
-      scale_x?: number;
-      scale_y?: number;
-    };
-    space?: {
-      id?: number;
-      name?: string;
-      room?: Room[];
-    };
-  }): Rsv {
-    const createdAt = rsv.created_at ? rsv.created_at : null;
-    const editedAt = rsv.edited_at ? rsv.edited_at : null;
-    const deletedAt = rsv.deleted_at ? rsv.deleted_at : null;
-    const room = rsv.room
-      ? new Room(
-          rsv.room.id ? rsv.room.id : 0,
-          rsv.room.supply_id ? rsv.room.supply_id : 0,
-          rsv.room.name ? rsv.room.name : '',
-          rsv.room.detail ? rsv.room.detail : null,
-          rsv.room.roomItem_id ? rsv.room.roomItem_id : 0,
-          rsv.space_id,
-          rsv.room.position_x ? rsv.room.position_x : 0,
-          rsv.room.position_y ? rsv.room.position_y : 0,
-          rsv.room.scale_x ? rsv.room.scale_x : 1,
-          rsv.room.scale_y ? rsv.room.scale_y : 1
-        )
-      : null;
-    const space = rsv.space
-      ? new Space(
-          rsv.space.id ? rsv.space.id : 0,
-          rsv.space.name ? rsv.space.name : '',
-          rsv.space.room ? rsv.space.room : []
-        )
-      : null;
-    return new Rsv(
-      rsv.id,
-      rsv.user_id,
-      rsv.space_id,
-      rsv.room_id,
-      rsv.start_time,
-      rsv.end_time,
-      createdAt,
-      editedAt,
-      deletedAt,
-      room,
-      space
-    );
   }
 
   async findAll(): Promise<Rsv[]> {
@@ -102,19 +36,7 @@ export class SbRsvRepository implements RsvRepository {
       throw new Error(`Error fetching reservations: ${error.message}`);
     }
 
-    return (
-      data as unknown as {
-        user_id: string;
-        room_id: number;
-        space_id: number;
-        id: string;
-        start_time: Date;
-        end_time: Date;
-        room: {
-          name: string;
-        };
-      }[]
-    ).map((rsv) => SbRsvRepository.mapToRsv(rsv));
+    return mapKeysToCamelCase(data) as Rsv[];
   }
 
   async findByUserId(id: string): Promise<Rsv[] | null> {
@@ -138,18 +60,7 @@ export class SbRsvRepository implements RsvRepository {
 
     if (error) throw new Error(error.message);
 
-    return (
-      data as unknown as {
-        id: string;
-        user_id: string;
-        space_id: number;
-        room_id: number;
-        start_time: Date;
-        end_time: Date;
-        space: { name: string };
-        room: { name: string };
-      }[]
-    ).map((rsv) => SbRsvRepository.mapToRsv(rsv));
+    return mapKeysToCamelCase(data) as Rsv[];
   }
 
   async findByRoomId(spaceId: number, roomId: number): Promise<Rsv[]> {

--- a/backend/common/infrastructures/repositories/SbSpaceRepository.ts
+++ b/backend/common/infrastructures/repositories/SbSpaceRepository.ts
@@ -16,10 +16,17 @@ export class SbSpaceRepository implements SpaceRepository {
   async findById(id: number): Promise<Space> {
     const { data, error } = await this.supabase
       .from('spaces')
-      .select('*')
+      .select(
+        `
+         *,
+        room: rooms (
+          *,
+          supplies (*)
+         )
+        `
+      )
       .eq('id', id)
       .single();
-
     if (error) {
       throw new Error(`공간 조회 중 오류 발생: ${error.message}`);
     }

--- a/backend/common/infrastructures/repositories/SbSpaceRepository.ts
+++ b/backend/common/infrastructures/repositories/SbSpaceRepository.ts
@@ -19,12 +19,13 @@ export class SbSpaceRepository implements SpaceRepository {
       .select(
         `
          *,
-        room: rooms (
+        rooms: room (
           *,
           supplies (*)
          )
         `
       )
+      // .select('*')
       .eq('id', id)
       .single();
     if (error) {

--- a/backend/spaces/dtos/GetSpaceDto.ts
+++ b/backend/spaces/dtos/GetSpaceDto.ts
@@ -7,6 +7,13 @@ export class GetSpaceDto {
     description?: string;
     createdAt?: Date;
     updatedAt?: Date;
+    width?: number;
+    height?: number;
+    scaleX?: number;
+    scaleY?: number;
+    positionX?: number;
+    positionY?: number;
+    supplies: { width: number; height: number; shape: string }[]; // 공급 정보, 필요시 추가 필드 정의 가능
   }[];
 
   constructor(
@@ -18,6 +25,13 @@ export class GetSpaceDto {
       description?: string;
       createdAt?: Date;
       updatedAt?: Date;
+      width?: number;
+      height?: number;
+      scaleX?: number;
+      scaleY?: number;
+      positionX?: number;
+      positionY?: number;
+      supplies: { width: number; height: number; shape: string }[]; // 공급 정보, 필요시 추가 필드 정의 가능
     }[]
   ) {
     this.id = id;


### PR DESCRIPTION
## 🔍 개요 (Overview)

기존에 Room 안에 supply_id를 따로 두고 있었는데, 제가 변경한 사항처럼 supply엔티티를 직접 참조하도록 하면 조회해오기가 수월합니다. 아래사항처럼 변경해도 될지 한번 확인 부탁 드리겠습니다. 다만, 위와 같이 변경할 경우 기존의 room 엔티티를 참조하던 부분에 수정, 변경이 필요합니다.

## ✅ 작업 사항 (Work Done)

- [ ]기존에 supply_id를 이용하여 데이터를 연결하는 방법에서 supply 엔티티를 직접 참조하도록 수정.



## 📸 스크린샷 (Screenshots)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->

| Before | After |
| :----: | :---: |
|        |       |


##  reviewers에게

<!-- 리뷰어가 특별히 신경써서 봐야 할 부분이 있다면 알려주세요. -->
<!-- 궁금한 점이나 논의가 필요한 부분도 좋습니다. -->

