### PR TITLE
fix: duplication 실패 시 처리 추가

### DIFF
--- a/app/(anon)/components/modals/signup/SignupModal.tsx
+++ b/app/(anon)/components/modals/signup/SignupModal.tsx
@@ -46,7 +46,7 @@ const SignupModal = ({ onClose }: SignupModalProps) => {
     message: string;
   }>(['duplicates'], '/duplicates', false, {
     email: email,
-  });
+  }, undefined, { retry: false });
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isValidEmail(e.target.value)) {
@@ -97,11 +97,14 @@ const SignupModal = ({ onClose }: SignupModalProps) => {
       alert('이메일 형식이 잘못되었습니다.');
       return;
     }
-    const { data } = await refetchWithParams({ email });
+    const { data, error } = await refetchWithParams({ email });
 
-    if (data?.available && data?.message) {
+    if (data?.available === true && data?.message) {
       setCheckedDuplication(true);
       alert(data?.message);
+    }
+    if (error && axios.isAxiosError<{ available: boolean; message: string }>(error) && error.response?.data?.available === false) {
+      alert(error.response.data.message);
     }
   };
 


### PR DESCRIPTION
## 🔍 개요 (Overview)

아이디 중복 체크 - 실패 처리 추가
성공에 대한 처리만 되어있어서 픽스합니다!

## ✅ 작업 사항 (Work Done)

- [x] react-query retry false 옵션추가
- [x] duplication api - 중복이거나 사용할 수 없는 경우 처리 추가

## 📸 스크린샷 (Screenshots)

## reviewers에게
Thanks to 테스트해주신 강현님
