### PR TITLE
Feat/loading 추가

### DIFF
--- a/app/(anon)/components/MainPage.module.css
+++ b/app/(anon)/components/MainPage.module.css
@@ -2,7 +2,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   padding: var(--spacing-8);
+  min-height: 700px;
 }
 
 .title {

--- a/app/(anon)/components/MainPage.tsx
+++ b/app/(anon)/components/MainPage.tsx
@@ -6,10 +6,11 @@ import styles from './MainPage.module.css';
 import { TitleText } from '@/ds/components/atoms/text/textWrapper';
 import { useGets } from '@/hooks/useGets';
 import { Space } from './types';
+import LoadingSpinner from '@/ds/components/atoms/loading/LoadingSpinner';
 
 const MainPage: React.FC = () => {
   const SPACE_ID = 150;
-  const { data } = useGets<Space>(['rooms'], `/spaces/${SPACE_ID}`);
+  const { data, isLoading } = useGets<Space>(['rooms'], `/spaces/${SPACE_ID}`);
 
   useEffect(() => {
     if (data) {
@@ -19,10 +20,19 @@ const MainPage: React.FC = () => {
 
   return (
     <div className={styles.mainPageContainer}>
-      <TitleText variant="primary" style={{ fontSize: 32, fontWeight: 'bold' }}>
-        {data?.spaceName}의 공간
-      </TitleText>
-      <Canvas rooms={data?.roomInfo || []} />
+      {isLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <>
+          <TitleText
+            variant="primary"
+            style={{ fontSize: 32, fontWeight: 'bold' }}
+          >
+            {data?.spaceName}의 공간
+          </TitleText>
+          <Canvas rooms={data?.roomInfo || []} />
+        </>
+      )}
     </div>
   );
 };

--- a/app/(anon)/components/modals/rooms/reservations/RoomRsvModal.tsx
+++ b/app/(anon)/components/modals/rooms/reservations/RoomRsvModal.tsx
@@ -11,6 +11,7 @@ import { CaptionText } from '@/ds/components/atoms/text/textWrapper';
 import { usePosts } from '@/hooks/usePosts';
 import { useSession } from '@/app/providers/SessionProvider';
 import { useRouter } from 'next/navigation';
+import LoadingSpinner from '@/ds/components/atoms/loading/LoadingSpinner';
 
 interface RoomRsvModalProps {
   onClose: () => void;
@@ -39,7 +40,7 @@ const RoomRsvModal = ({ onClose, room }: RoomRsvModalProps) => {
   };
   const onError = () => {};
   const { mutate } = usePosts({ onSuccess, onError });
-  const { data } = useGets<{ schedule: number[] }>(
+  const { data, isLoading } = useGets<{ schedule: number[] }>(
     ['room-rervations'],
     '/rooms/reservations',
     true,
@@ -109,11 +110,15 @@ const RoomRsvModal = ({ onClose, room }: RoomRsvModalProps) => {
               최대 4시간 예약이 가능합니다
             </CaptionText>
           </div>
-          <TimePicker
-            availableTimes={nineToFive}
-            reservedTimes={reservedTimes}
-            onTimeSelect={onTimeSelect}
-          />
+          {isLoading ? (
+            <LoadingSpinner size={30} />
+          ) : (
+            <TimePicker
+              availableTimes={nineToFive}
+              reservedTimes={reservedTimes}
+              onTimeSelect={onTimeSelect}
+            />
+          )}
           <div className={styles['button-container']}>
             <Button variant="primary" size="sm" onClick={handleClickRsv}>
               예약하기

--- a/ds/components/atoms/loading/LoadingSpinner.module.css
+++ b/ds/components/atoms/loading/LoadingSpinner.module.css
@@ -1,0 +1,23 @@
+.spinner {
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/ds/components/atoms/loading/LoadingSpinner.stories.tsx
+++ b/ds/components/atoms/loading/LoadingSpinner.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import LoadingSpinner from './LoadingSpinner';
+
+const meta = {
+  title: 'Components/Atoms/LoadingSpinner',
+  component: LoadingSpinner,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: { type: 'range', min: 16, max: 128, step: 8 },
+    },
+    color: {
+      control: 'color',
+    },
+  },
+} satisfies Meta<typeof LoadingSpinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 48,
+  },
+};
+
+export const CustomColor: Story = {
+  args: {
+    size: 64,
+    color: '#ff0000',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 24,
+  },
+};

--- a/ds/components/atoms/loading/LoadingSpinner.tsx
+++ b/ds/components/atoms/loading/LoadingSpinner.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { LoadingSpinnerProps } from './LoadingSpinner.types';
+import styles from './LoadingSpinner.module.css';
+import '../../../styles/globals.css';
+
+const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
+  size = 48,
+  color = 'var(--color-primary)',
+}) => {
+  const borderWidth = Math.max(2, size / 10);
+
+  return (
+    <div
+      className={styles.spinner}
+      style={{
+        width: size,
+        height: size,
+        border: `${borderWidth}px solid transparent`,
+        borderTopColor: color,
+        borderLeftColor: color,
+      }}
+      role="status"
+    >
+      <span className={styles.srOnly}>Loading...</span>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/ds/components/atoms/loading/LoadingSpinner.types.ts
+++ b/ds/components/atoms/loading/LoadingSpinner.types.ts
@@ -1,0 +1,5 @@
+export interface LoadingSpinnerProps {
+  size?: number;
+  color?: string;
+  className?: string;
+}


### PR DESCRIPTION
## 🔍 개요 (Overview)

로딩 컴포넌트 추가

## ✅ 작업 사항 (Work Done)

- [x] ds/components/atoms에 loadin spinner 추가
- [x] 메인페이지 공간 조회 api에 로딩스피너 추가
- [x] 방의 예약 조회 api에 로딩스피너 추가 

## 📸 스크린샷 (Screenshots)

https://github.com/user-attachments/assets/870e479e-c7d1-427a-8aec-7fe88e0a69ef


## reviewers에게

Suspense를 사용하려고 했는데,
그러면 useSuspenseQuery를 사용해야 하는데 useSuspenseQuery + Suspense + react-error-boundary 이 조합으로 처리하려고 하니
"Uncaught Error: Switched to client rendering because the server rendering errored" 에러가 계속 발생하여
useQuery의 isLoading 값을 활용해 conditional render로 처리하는 것으로 해두었습니다

더 나은 방법이 있다면 알려주세요🙏