### PR TITLE
Feat/toast ui 추가

### DIFF
--- a/app/(anon)/components/modals/rooms/reservations/RoomRsvModal.tsx
+++ b/app/(anon)/components/modals/rooms/reservations/RoomRsvModal.tsx
@@ -12,6 +12,7 @@ import { usePosts } from '@/hooks/usePosts';
 import { useSession } from '@/app/providers/SessionProvider';
 import { useRouter } from 'next/navigation';
 import LoadingSpinner from '@/ds/components/atoms/loading/LoadingSpinner';
+import { useToastStore } from '@/hooks/useToast';
 
 interface RoomRsvModalProps {
   onClose: () => void;
@@ -53,6 +54,7 @@ const RoomRsvModal = ({ onClose, room }: RoomRsvModalProps) => {
   );
   const { user } = useSession();
   const reservationTime = useRef<number[] | null>(null);
+  const { showToast } = useToastStore();
 
   const onTimeSelect = (start: number | null, end: number | null) => {
     if (start && end) {
@@ -76,11 +78,11 @@ const RoomRsvModal = ({ onClose, room }: RoomRsvModalProps) => {
 
   const handleClickRsv = () => {
     if (!user) {
-      alert('로그인 후 사용해주세요!');
+      showToast('로그인 후 사용해주세요!', 'danger');
       return;
     }
     if (!reservationTime.current || reservationTime.current.length < 2) {
-      alert('예약시간을 정확히 선택해주세요');
+      showToast('예약시간을 정확히 선택해주세요', 'accent');
       return;
     }
 

--- a/app/(anon)/components/modals/signin/SigninModal.tsx
+++ b/app/(anon)/components/modals/signin/SigninModal.tsx
@@ -7,6 +7,7 @@ import { useRef } from 'react';
 import { usePosts } from '@/hooks/usePosts';
 import { useSession } from '@/app/providers/SessionProvider';
 import { useRouter } from 'next/navigation';
+import { useToastStore } from '@/hooks/useToast';
 
 interface SigninModalProps {
   onClose: () => void;
@@ -17,6 +18,7 @@ const SigninModal = ({ onClose, openSignup }: SigninModalProps) => {
   const passwordRef = useRef<HTMLInputElement>(null);
   const { refreshSession } = useSession();
   const router = useRouter();
+  const { showToast } = useToastStore();
   const onSuccess = (data: {
     message: string;
     success: boolean;
@@ -34,7 +36,9 @@ const SigninModal = ({ onClose, openSignup }: SigninModalProps) => {
     }
     onClose();
   };
-  const onError = () => {};
+  const onError = () => {
+    showToast('아이디 또는 비밀번호 오류!', 'accent');
+  };
   const { mutate } = usePosts({ onSuccess, onError });
 
   const handleClickSignin = async () => {

--- a/app/(anon)/components/modals/signup/SignupModal.tsx
+++ b/app/(anon)/components/modals/signup/SignupModal.tsx
@@ -8,6 +8,7 @@ import { isValidEmail, isValidPassword } from '@/utils/validation';
 import { usePosts } from '@/hooks/usePosts';
 import { useGets } from '@/hooks/useGets';
 import { useSession } from '@/app/providers/SessionProvider';
+import { useToastStore } from '@/hooks/useToast';
 
 interface SignupModalProps {
   onClose: () => void;
@@ -15,8 +16,9 @@ interface SignupModalProps {
 
 const SignupModal = ({ onClose }: SignupModalProps) => {
   const { refreshSession } = useSession();
+  const { showToast } = useToastStore();
   const onSuccess = () => {
-    alert('회원가입이 성공적으로 완료되었습니다!');
+    showToast('회원가입이 성공적으로 완료되었습니다!', 'primary');
     refreshSession();
     onClose();
   };
@@ -44,9 +46,16 @@ const SignupModal = ({ onClose }: SignupModalProps) => {
   const { refetchWithParams } = useGets<{
     available: boolean;
     message: string;
-  }>(['duplicates'], '/duplicates', false, {
-    email: email,
-  }, undefined, { retry: false });
+  }>(
+    ['duplicates'],
+    '/duplicates',
+    false,
+    {
+      email: email,
+    },
+    undefined,
+    { retry: false }
+  );
 
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!isValidEmail(e.target.value)) {
@@ -81,7 +90,7 @@ const SignupModal = ({ onClose }: SignupModalProps) => {
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!checkedDuplication) {
-      alert('이메일 중복 확인은 필수입니다.');
+      showToast('이메일 중복 확인은 필수입니다.', 'danger');
       return;
     }
     if (e.target.value?.length <= 0) {
@@ -94,27 +103,31 @@ const SignupModal = ({ onClose }: SignupModalProps) => {
 
   const handleClickCheckDup = async () => {
     if (!isValidEmail(email)) {
-      alert('이메일 형식이 잘못되었습니다.');
+      showToast('이메일 형식이 잘못되었습니다.', 'danger');
       return;
     }
     const { data, error } = await refetchWithParams({ email });
 
     if (data?.available === true && data?.message) {
       setCheckedDuplication(true);
-      alert(data?.message);
+      showToast(data?.message, 'danger');
     }
-    if (error && axios.isAxiosError<{ available: boolean; message: string }>(error) && error.response?.data?.available === false) {
-      alert(error.response.data.message);
+    if (
+      error &&
+      axios.isAxiosError<{ available: boolean; message: string }>(error) &&
+      error.response?.data?.available === false
+    ) {
+      showToast(error.response.data.message, 'danger');
     }
   };
 
   const handleClickSignup = () => {
     if (!name || !email || !password || !passwordCheck) {
-      alert('필수 값을 모두 입력하세요.');
+      showToast('필수 값을 모두 입력하세요.', 'danger');
       return;
     }
     if (password !== passwordCheck) {
-      alert('비밀번호가 일치하지 않습니다.');
+      showToast('비밀번호가 일치하지 않습니다.', 'danger');
       return;
     }
     if (isValidEmail(email) && isValidPassword(password)) {

--- a/app/components/ToastContainer.tsx
+++ b/app/components/ToastContainer.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import Toast from '@/ds/components/atoms/toast/Toast';
+import { useToastStore } from '@/hooks/useToast';
+
+const ToastContainer = () => {
+  const { toasts, dismissToast } = useToastStore();
+
+  return (
+    <>
+      {toasts.map(({ id, message, variant }) => (
+        <Toast
+          key={id}
+          message={message}
+          variant={variant}
+          onDismiss={() => dismissToast(id)}
+        />
+      ))}
+    </>
+  );
+};
+
+export default ToastContainer;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { SessionProvider } from './providers/SessionProvider';
 import { ReactQueryProvider } from './providers/ReactQueryProvider';
 import { Metadata } from 'next';
+import ToastContainer from '@/app/components/ToastContainer';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -29,7 +30,10 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ReactQueryProvider>
-          <SessionProvider>{children}</SessionProvider>
+          <SessionProvider>
+            {children}
+            <ToastContainer />
+          </SessionProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/ds/components/atoms/toast/Toast.module.css
+++ b/ds/components/atoms/toast/Toast.module.css
@@ -6,7 +6,7 @@
   padding: 16px;
   border-radius: 8px;
   font-size: 16px;
-  z-index: 1000;
+  z-index: 2000;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/ds/components/atoms/toast/Toast.module.css
+++ b/ds/components/atoms/toast/Toast.module.css
@@ -1,0 +1,42 @@
+.toast {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 16px;
+  border-radius: 8px;
+  font-size: 16px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
+}
+
+.toast-primary {
+  background-color: var(--toast-variant-primary-bg);
+  color: var(--toast-variant-primary-color);
+}
+
+.toast-secondary {
+  background-color: var(--toast-variant-secondary-bg);
+  color: var(--toast-variant-secondary-color);
+}
+
+.toast-accent {
+  background-color: var(--toast-variant-accent-bg);
+  color: var(--toast-variant-accent-color);
+}
+
+.toast-danger {
+  background-color: var(--toast-variant-danger-bg);
+  color: var(--toast-variant-danger-color);
+}
+
+.toast-hidden {
+  opacity: 0;
+  transform: translateX(-50%) translateY(-20px);
+}

--- a/ds/components/atoms/toast/Toast.stories.ts
+++ b/ds/components/atoms/toast/Toast.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import Toast from './Toast';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Components/Atoms/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+  argTypes: {
+    message: { control: 'text' },
+    variant: { control: { type: 'radio', options: ['success', 'error'] } },
+    duration: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+export const Success: Story = {
+  args: {
+    message: 'This is a success message!',
+    variant: 'primary',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    message: 'This is an error message!',
+    variant: 'accent',
+  },
+};

--- a/ds/components/atoms/toast/Toast.tsx
+++ b/ds/components/atoms/toast/Toast.tsx
@@ -3,7 +3,12 @@ import styles from './Toast.module.css';
 import '../../../styles/globals.css';
 import { ToastProps } from './Toast.types';
 
-const Toast: React.FC<ToastProps> = ({ message, variant, duration = 3000 }) => {
+const Toast: React.FC<ToastProps> = ({
+  message,
+  variant,
+  duration = 1500,
+  onDismiss,
+}) => {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -13,6 +18,15 @@ const Toast: React.FC<ToastProps> = ({ message, variant, duration = 3000 }) => {
 
     return () => clearTimeout(timer);
   }, [duration]);
+
+  useEffect(() => {
+    if (!visible) {
+      const timer = setTimeout(() => {
+        onDismiss();
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [visible, onDismiss]);
 
   const className = [
     styles.toast,

--- a/ds/components/atoms/toast/Toast.tsx
+++ b/ds/components/atoms/toast/Toast.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import styles from './Toast.module.css';
+import '../../../styles/globals.css';
+import { ToastProps } from './Toast.types';
+
+const Toast: React.FC<ToastProps> = ({ message, variant, duration = 3000 }) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+    }, duration);
+
+    return () => clearTimeout(timer);
+  }, [duration]);
+
+  const className = [
+    styles.toast,
+    styles[`toast-${variant}`],
+    visible ? '' : styles['toast-hidden'],
+  ];
+
+  return <div className={className.filter(Boolean).join(' ')}>{message}</div>;
+};
+
+export default Toast;

--- a/ds/components/atoms/toast/Toast.types.ts
+++ b/ds/components/atoms/toast/Toast.types.ts
@@ -1,0 +1,8 @@
+import { ToastVariant } from '@/ds/styles/tokens/toast/variant';
+
+export interface ToastProps {
+  message: string;
+  variant: ToastVariant;
+  duration?: number;
+  onClose: () => void;
+}

--- a/ds/components/atoms/toast/Toast.types.ts
+++ b/ds/components/atoms/toast/Toast.types.ts
@@ -4,5 +4,5 @@ export interface ToastProps {
   message: string;
   variant: ToastVariant;
   duration?: number;
-  onClose: () => void;
+  onDismiss: () => void;
 }

--- a/ds/styles/globals.css
+++ b/ds/styles/globals.css
@@ -77,6 +77,16 @@
   --text-size-xl-font-weight: 800;
   --text-size-xl-line-height: 32px;
 
+  /* Toast Variant Tokens */
+  --toast-variant-primary-bg: var(--color-primary-dark);
+  --toast-variant-primary-color: var(--color-background);
+  --toast-variant-secondary-bg: var(--color-primary);
+  --toast-variant-secondary-color: var(--color-text-primary);
+  --toast-variant-accent-bg: var(--color-accent);
+  --toast-variant-accent-color: var(--color-text-primary);
+  --toast-variant-danger-bg: var(--color-error-dark);
+  --toast-variant-danger-color: var(--color-background);
+
   /* Button Variant Tokens */
   /* Primary */
   --button-variant-primary-bg: var(--color-primary);

--- a/ds/styles/tokens/toast/variant.ts
+++ b/ds/styles/tokens/toast/variant.ts
@@ -1,0 +1,22 @@
+import { color } from '../color';
+
+export const toastVariants = {
+  primary: {
+    background: color.primaryDark,
+    color: color.background,
+  },
+  secondary: {
+    background: color.primary,
+    color: color.textPrimary,
+  },
+  accent: {
+    background: color.accent,
+    color: color.textPrimary,
+  },
+  danger: {
+    background: color.errorDark,
+    color: color.background,
+  },
+};
+
+export type ToastVariant = keyof typeof toastVariants;

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,27 @@
+import { ToastVariant } from '@/ds/styles/tokens/toast/variant';
+import { create } from 'zustand';
+
+interface Toast {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  showToast: (message: string, variant: ToastVariant) => void;
+  dismissToast: (id: number) => void;
+}
+
+let toastId = 0;
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  showToast: (message, variant) => {
+    const id = toastId++;
+    set((state) => ({ toasts: [...state.toasts, { id, message, variant }] }));
+  },
+  dismissToast: (id) => {
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+  },
+}));


### PR DESCRIPTION
## 🔍 개요 (Overview)

alert -> toast

## ✅ 작업 사항 (Work Done)

- [x] toast 컴포넌트 생성
- [x] toast 사용하기 위한 커스텀 훅 생성
- [x] alert를 사용하던 부분(RoomRsvModal, SignupModal, SigninModal)을 토스트로 변경

## 📸 스크린샷 (Screenshots)

https://github.com/user-attachments/assets/3f1c4eb3-0ce0-4b1d-a3e0-e6a869a2f644

## reviewers에게

토스트를 사용하고 싶으시다면
```const { showToast } = useToastStore();``` 하신 후,

alert 처럼 사용시에는
```showToast('로그인 후 사용해주세요!', 'danger');```
위 처럼 사용하시면 됩니다! 토스트 타입은 primary(짙은 초록), secondary(연한 초록), accent(노랑), danger(빨강)입니다
