### PR TITLE
style: input의 오류 메시지 absolute하게 변경

### DIFF
--- a/ds/components/atoms/input/Input.module.css
+++ b/ds/components/atoms/input/Input.module.css
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-1);
+  position: relative;
+  margin-bottom: var(--spacin-2);
 }
 
 .ttabook-input {
@@ -79,4 +81,10 @@
   height: var(--input-size-sm-height);
   padding: var(--input-size-sm-padding);
   font-size: var(--input-size-sm-font-size);
+}
+
+.error-message {
+  position: absolute;
+  bottom: calc(var(--spacing-4) * -1);
+  left: 0;
 }

--- a/ds/components/atoms/input/Input.tsx
+++ b/ds/components/atoms/input/Input.tsx
@@ -33,7 +33,13 @@ const Input: React.FC<InputProps> = ({
         {...props}
         style={{ width: isFullWidth ? '100%' : '', boxSizing: 'border-box' }}
       />
-      {error && <CaptionText variant="danger">{error}</CaptionText>}
+      {error && (
+        <div className={styles['error-message']}>
+          <CaptionText variant="danger" style={{ margin: 0 }}>
+            {error}
+          </CaptionText>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🔍 개요 (Overview)

signup 시 input 의 오류 메시지 때문에 버튼과 align이 맞지 않는 현상 해결

## ✅ 작업 사항 (Work Done)

- [x] ds/components/atoms/input의 오류메시지 css 변경

## 📸 스크린샷 (Screenshots)

| Before |
<img width="499" height="676" alt="스크린샷 2025-07-19 오전 1 28 37" src="https://github.com/user-attachments/assets/8a391437-bf63-4aae-9ba4-c971d7682d4e" />


| After |
<img width="499" height="661" alt="스크린샷 2025-07-19 오전 1 26 53" src="https://github.com/user-attachments/assets/cd5ff031-537d-4433-bc83-6f5f753bbaf3" />



## reviewers에게

QA 시작하자마자 발견한 css 오류 해결했습니다