### PR TITLE
feat: PUT 및 DELETE React Query 훅 추가

### DIFF
--- a/hooks/useDeletes.ts
+++ b/hooks/useDeletes.ts
@@ -1,0 +1,43 @@
+import { useMutation } from '@tanstack/react-query';
+import axios, { AxiosResponse } from 'axios';
+
+interface DeleteProps<TResponse> {
+  onSuccess: (data: TResponse) => void;
+  onError: (err: unknown) => void;
+}
+
+interface MutateProps<TRequest> {
+  deleteData?: TRequest;
+  path: string;
+}
+
+const useDeletes = <TRequest, TResponse>({
+  onSuccess,
+  onError,
+}: DeleteProps<TResponse>) => {
+  const { isError, isPending, isPaused, isSuccess, mutate, mutateAsync } =
+    useMutation<TResponse, unknown, MutateProps<TRequest>>({
+      mutationFn: async ({
+        deleteData,
+        path,
+      }: {
+        deleteData?: unknown;
+        path: string;
+      }) => {
+        const response: AxiosResponse<TResponse> = await axios.delete(
+          `${process.env.NEXT_PUBLIC_BASE_URL}${path}`,
+          {
+            data: deleteData,
+            withCredentials: true,
+          }
+        );
+        return response.data;
+      },
+      onSuccess: onSuccess,
+      onError: onError,
+    });
+
+  return { isError, isPending, isPaused, isSuccess, mutate, mutateAsync };
+};
+
+export { useDeletes };

--- a/hooks/usePuts.ts
+++ b/hooks/usePuts.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+import axios, { AxiosResponse } from 'axios';
+
+interface PutProps<TResponse> {
+  onSuccess: (data: TResponse) => void;
+  onError: (err: unknown) => void;
+}
+
+interface MutateProps<TRequest> {
+  putData?: TRequest;
+  path: string;
+}
+
+const usePuts = <TRequest, TResponse>({
+  onSuccess,
+  onError,
+}: PutProps<TResponse>) => {
+  const { isError, isPending, isPaused, isSuccess, mutate, mutateAsync } =
+    useMutation<TResponse, unknown, MutateProps<TRequest>>({
+      mutationFn: async ({
+        putData,
+        path,
+      }: {
+        putData?: unknown;
+        path: string;
+      }) => {
+        const response: AxiosResponse<TResponse> = await axios.put(
+          `${process.env.NEXT_PUBLIC_BASE_URL}${path}`,
+          putData,
+          { withCredentials: true }
+        );
+        return response.data;
+      },
+      onSuccess: onSuccess,
+      onError: onError,
+    });
+
+  return { isError, isPending, isPaused, isSuccess, mutate, mutateAsync };
+};
+
+export { usePuts };


### PR DESCRIPTION
## 개요
기존 POST/GET 훅과 함께 완전한 CRUD 작업을 지원하기 위해 PUT 및 DELETE React Query 훅을 추가했습니다.

## 주요 변경사항
- **usePuts**: PUT 요청을 위한 React Query 훅 구현
- **useDeletes**: DELETE 요청을 위한 React Query 훅 구현

## 기술적 세부사항
- 기존 `usePosts` 훅과 일관된 API 패턴 유지
- TypeScript 제네릭으로 요청/응답 타입 안전성 보장
- `withCredentials: true` 설정으로 인증 쿠키 포함
- onSuccess/onError 콜백 지원

## 사용 예시
```typescript
// PUT 요청
const updateMutation = usePuts<UpdateRequest, UpdateResponse>({
  onSuccess: (data) => console.log('Updated:', data),
  onError: (error) => console.error('Error:', error),
});

// DELETE 요청  
const deleteMutation = useDeletes<DeleteRequest, DeleteResponse>({
  onSuccess: () => console.log('Deleted successfully'),
  onError: (error) => console.error('Delete failed:', error),
});
```

## 테스트 계획
- [ ] PUT 요청 동작 확인
- [ ] DELETE 요청 동작 확인
- [ ] 타입 안전성 검증
- [ ] 에러 핸들링 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)